### PR TITLE
Properly format translation files

### DIFF
--- a/po/com.github.louis77.tuner.pot
+++ b/po/com.github.louis77.tuner.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.louis77.tuner\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-06 01:26+0200\n"
+"POT-Creation-Date: 2020-09-28 11:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,11 +111,11 @@ msgstr ""
 msgid "Station name"
 msgstr ""
 
-#: src/Widgets/HeaderBar.vala:134
+#: src/Widgets/HeaderBar.vala:130
 msgid "Star this station"
 msgstr ""
 
-#: src/Widgets/HeaderBar.vala:183
+#: src/Widgets/HeaderBar.vala:179
 msgid "Playing"
 msgstr ""
 
@@ -131,7 +131,6 @@ msgstr ""
 msgid "Genres"
 msgstr ""
 
-#. Discover Box
 #: src/Widgets/Window.vala:122
 msgid "Discover"
 msgstr ""
@@ -144,7 +143,6 @@ msgstr ""
 msgid "Discover more stations"
 msgstr ""
 
-#. Trending Box
 #: src/Widgets/Window.vala:153
 msgid "Trending"
 msgstr ""
@@ -153,7 +151,6 @@ msgstr ""
 msgid "Trending in the last 24 hours"
 msgstr ""
 
-#. Popular Box
 #: src/Widgets/Window.vala:174
 msgid "Popular"
 msgstr ""
@@ -162,7 +159,6 @@ msgstr ""
 msgid "Most-listened over 24 hours"
 msgstr ""
 
-#. Country-specific stations list
 #: src/Widgets/Window.vala:194
 msgid "Your Country"
 msgstr ""
@@ -171,12 +167,10 @@ msgstr ""
 msgid "Top 100 in"
 msgstr ""
 
-#. Favourites Box
 #: src/Widgets/Window.vala:231 src/Widgets/Window.vala:235
 msgid "Starred by You"
 msgstr ""
 
-#. Search Results Box
 #: src/Widgets/Window.vala:244
 msgid "Recent Search"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -1,13 +1,21 @@
+# German translations for com.github.louis77.tuner package.
+# Copyright (C) 2020 THE com.github.louis77.tuner'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the com.github.louis77.tuner package.
+# Automatically generated, 2020.
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Tuner\n"
+"Project-Id-Version: com.github.louis77.tuner\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-06 01:26+0200\n"
+"POT-Creation-Date: 2020-09-28 11:51+0200\n"
+"PO-Revision-Date: 2020-09-28 11:48+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: POEditor.com\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: src/Models/Genre.vala:35
 msgid "70s"
@@ -107,11 +115,11 @@ msgstr "Einstellungen"
 msgid "Station name"
 msgstr "Stationsname"
 
-#: src/Widgets/HeaderBar.vala:134
+#: src/Widgets/HeaderBar.vala:130
 msgid "Star this station"
 msgstr "Als Favorit markieren"
 
-#: src/Widgets/HeaderBar.vala:183
+#: src/Widgets/HeaderBar.vala:179
 msgid "Playing"
 msgstr "Läuft"
 
@@ -127,7 +135,6 @@ msgstr ""
 msgid "Genres"
 msgstr "Genre"
 
-#. Discover Box
 #: src/Widgets/Window.vala:122
 msgid "Discover"
 msgstr "Entdecken"
@@ -140,7 +147,6 @@ msgstr "Entdecke Radio Stationen"
 msgid "Discover more stations"
 msgstr "Entdecke mehr Stationen"
 
-#. Trending Box
 #: src/Widgets/Window.vala:153
 msgid "Trending"
 msgstr "Im Trend"
@@ -149,7 +155,6 @@ msgstr "Im Trend"
 msgid "Trending in the last 24 hours"
 msgstr "Im Trend in den letzten 24 Stunden"
 
-#. Popular Box
 #: src/Widgets/Window.vala:174
 msgid "Popular"
 msgstr "Populär"
@@ -158,7 +163,6 @@ msgstr "Populär"
 msgid "Most-listened over 24 hours"
 msgstr "Am meisten gehört in den letzten 24 Stunden"
 
-#. Country-specific stations list
 #: src/Widgets/Window.vala:194
 #, fuzzy
 msgid "Your Country"
@@ -168,12 +172,10 @@ msgstr "Country"
 msgid "Top 100 in"
 msgstr ""
 
-#. Favourites Box
 #: src/Widgets/Window.vala:231 src/Widgets/Window.vala:235
 msgid "Starred by You"
 msgstr "Von Dir markiert"
 
-#. Search Results Box
 #: src/Widgets/Window.vala:244
 #, fuzzy
 msgid "Recent Search"
@@ -182,18 +184,3 @@ msgstr "Suche"
 #: src/Widgets/Window.vala:248
 msgid "Search"
 msgstr "Suche"
-
-#~ msgid "Paused"
-#~ msgstr "Angehalten"
-
-#~ msgid "Connecting"
-#~ msgstr "Verbinde"
-
-#~ msgid "Search Result"
-#~ msgstr "Suchergebnis"
-
-#~ msgid "Buffering"
-#~ msgstr "Puffere"
-
-#~ msgid "Stopped"
-#~ msgstr "Angehalten"

--- a/po/extra/de.po
+++ b/po/extra/de.po
@@ -1,13 +1,21 @@
+# German translations for extra package.
+# Copyright (C) 2020 THE extra'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the extra package.
+# Automatically generated, 2020.
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Tuner AppStream\n"
+"Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-10 19:42+0200\n"
+"POT-Creation-Date: 2020-09-28 11:55+0200\n"
+"PO-Revision-Date: 2020-09-28 11:53+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: POEditor.com\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/com.github.louis77.tuner.desktop.in:4
 #: data/com.github.louis77.tuner.appdata.xml.in:8
@@ -15,7 +23,8 @@ msgid "Tuner"
 msgstr "Tuner"
 
 #: data/com.github.louis77.tuner.desktop.in:5
-msgid "Internet Radio Station Receiver"
+#, fuzzy
+msgid "Internet Radio Player"
 msgstr "Internet Radio Empfänger"
 
 #: data/com.github.louis77.tuner.desktop.in:6
@@ -31,14 +40,18 @@ msgid "Radio;Audio;Listen;Stations;Receiver;"
 msgstr "Radio;Audio;Listen;Stations;Receiver;"
 
 #: data/com.github.louis77.tuner.appdata.xml.in:9
+msgid "Louis Brauer"
+msgstr "Louis Brauer"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:11
 msgid "Discover and listen to internet radio stations"
 msgstr "Entdecke und empfange Internet Radio-Stationen"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:12
+#: data/com.github.louis77.tuner.appdata.xml.in:14
 msgid "Make listening to internet radio stations fun again!"
 msgstr "Endlich wieder Spass beim Empfangen von Internet Radio-Stationen!"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:13
+#: data/com.github.louis77.tuner.appdata.xml.in:15
 msgid ""
 "Instead of providing you with all the stations you already know, Tuner "
 "presents you a new selection of stations from all over the world every time "
@@ -48,39 +61,81 @@ msgstr ""
 "zeigt Dir Tuner bei jedem Start eine neue Auswahl von Stationen aus aller "
 "Welt. Drücke einfach den Mischen-Button um eine neue Auswahl zu erhalten."
 
-#: data/com.github.louis77.tuner.appdata.xml.in:16
+#: data/com.github.louis77.tuner.appdata.xml.in:18
 msgid "Tuner uses the community-driven station catalog radio-browser.info."
 msgstr ""
 "Tuner benutzt das offene Community-Radio-Verzeichnis von radio-browser.info"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:18
+#: data/com.github.louis77.tuner.appdata.xml.in:20
 msgid "Discover new stations every day"
 msgstr "Entdecke jeden Tag neue Radio-Stationen"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:19
-msgid "Star stations you like"
+#: data/com.github.louis77.tuner.appdata.xml.in:21
+#, fuzzy
+msgid "Star stations you like and visit their website"
 msgstr "Markiere deine Favoriten"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:20
+#: data/com.github.louis77.tuner.appdata.xml.in:22
 msgid "Control Tuner from your volume indicator"
 msgstr "Steuere Tuner von deinem System-Lautstärkeregler"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:33
-msgid "Louis Brauer"
-msgstr "Louis Brauer"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:63
-#: data/com.github.louis77.tuner.appdata.xml.in:84
+#: data/com.github.louis77.tuner.appdata.xml.in:64
+#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:116
 msgid "New features:"
 msgstr "Neue Funktionen:"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:65
+#: data/com.github.louis77.tuner.appdata.xml.in:66
+msgid "Show the current track playing if supported by station"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:67
+msgid "Show Top 100 stations of user country if detectable"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:68
+msgid "\"Visit Website\" link in station context menu"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:70
+#: data/com.github.louis77.tuner.appdata.xml.in:82
+#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:123
+msgid "Other improvements:"
+msgstr "Sonstige Verbesserungen:"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:72
+#, fuzzy
+msgid "Added Dutch translation"
+msgstr "Französisch-Übersetzung hinzugefügt"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:130
+msgid "Bugfixes:"
+msgstr "Fehlerbehebungen:"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:76
+#: data/com.github.louis77.tuner.appdata.xml.in:89
+msgid "Fix missing icons for non elementary OS systems"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:84
+msgid "Add manual dark mode switch in settings"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:85
+msgid "Compact sidebar and content window"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:97
 msgid "Right-click a station to add or remove to favourites directly"
 msgstr ""
 "Klicken Sie mit der rechten Maustaste auf eine Station, um sie direkt zu "
 "Favoriten hinzuzufügen oder daraus zu entfernen"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:66
+#: data/com.github.louis77.tuner.appdata.xml.in:98
 msgid ""
 "Add settings menu with \"Do-Not-Track\" option, disables sending station "
 "listening events to radio-browser.org"
@@ -88,16 +143,11 @@ msgstr ""
 "Einstellungsmenü mit der Option \"Nicht verfolgen\" hinzugefügt um das "
 "Senden von Ereignissen an radio-browser.org zu verhindern"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:67
+#: data/com.github.louis77.tuner.appdata.xml.in:99
 msgid "Add About dialog"
 msgstr "Über Dialog hinzugefügt "
 
-#: data/com.github.louis77.tuner.appdata.xml.in:69
-#: data/com.github.louis77.tuner.appdata.xml.in:91
-msgid "Other improvements:"
-msgstr "Sonstige Verbesserungen:"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:71
+#: data/com.github.louis77.tuner.appdata.xml.in:103
 msgid ""
 "If a station is already in your favourites, you'll see a little star in the "
 "title"
@@ -105,7 +155,7 @@ msgstr ""
 "Wenn sich ein Sender bereits in Ihren Favoriten befindet, wird im Titel ein "
 "kleiner Stern angezeigt"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:72
+#: data/com.github.louis77.tuner.appdata.xml.in:104
 msgid ""
 "Randomly selects one of the available radio-browser.org servers (was always "
 "de1 before)"
@@ -113,7 +163,7 @@ msgstr ""
 "Wählt zufällig einen der verfügbaren radio-browser.org-Server aus (war "
 "vorher immer de1)"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:73
+#: data/com.github.louis77.tuner.appdata.xml.in:105
 msgid ""
 "Favourites are now stored in a local favourites.json file to improve app "
 "startup time"
@@ -121,69 +171,64 @@ msgstr ""
 "Favoriten werden jetzt in einer lokalen Datei favourites.json gespeichert, "
 "um die Startzeit der App zu verbessern"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:106
 #, fuzzy
 msgid "Added Italian translation"
 msgstr "Italienisch-Übersetzung hinzugefügt"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:76
-#: data/com.github.louis77.tuner.appdata.xml.in:98
-msgid "Bugfixes:"
-msgstr "Fehlerbehebungen:"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:78
+#: data/com.github.louis77.tuner.appdata.xml.in:110
 msgid ""
 "Fix broken dark theme support (elementary and Adwaita dark look fine now)"
 msgstr ""
 "Behebung der Unterstützung für defekte dunkle Themen (elementary und Adwaita "
 "Dark sehen jetzt gut aus)"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:86
+#: data/com.github.louis77.tuner.appdata.xml.in:118
 msgid "Search for radio stations"
 msgstr "Suche nach Radio-Stationen"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:119
 msgid "New \"Genres\" section with select popular genres"
 msgstr "Neuer \"Genre\"-Abschnitt mit ausgewählten Genre"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:88
+#: data/com.github.louis77.tuner.appdata.xml.in:120
 msgid "Added French translation"
 msgstr "Französisch-Übersetzung hinzugefügt"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:89
+#: data/com.github.louis77.tuner.appdata.xml.in:121
 msgid "Added German translation"
 msgstr "Deutsch-Übersetzung hinzugefügt"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:93
+#: data/com.github.louis77.tuner.appdata.xml.in:125
 msgid "Each section now displays the most-voted-for 40 stations"
 msgstr "Jeder Abschnitt zeigt"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:94
+#: data/com.github.louis77.tuner.appdata.xml.in:126
 msgid "Station images are now being cached"
 msgstr "Stations-Bilder werden nun zwischengespeichert"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:127
 msgid "The app icon now appears more vertically centered"
 msgstr "Das App-Icon ist nun vertikal ausgerichtet"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:96
+#: data/com.github.louis77.tuner.appdata.xml.in:128
 msgid "Station images are now always the same size"
 msgstr "Stations-Bilder haben nun eine konsistente Grösse"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:100
+#: data/com.github.louis77.tuner.appdata.xml.in:132
 msgid "Fixed a bug where starred stations appeared as unstarred"
 msgstr ""
 "Einen Fehler behoben, bei dem markierte Stationen als nicht markiert "
 "angezeigt wurden"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:133
 msgid "Display a nice API error screen"
 msgstr "Zeige Hinweis falls Datenabruf fehlschlägt"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:140
 msgid "New sidebar menu with different selections and your favourite stations."
 msgstr "Neue Seitenleiste mit verschiedenen Vorauswahlen und deinen Favoriten"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:113
+#: data/com.github.louis77.tuner.appdata.xml.in:145
 msgid "Initial release"
 msgstr "Erste Ausgabe"

--- a/po/extra/extra.pot
+++ b/po/extra/extra.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-10 19:42+0200\n"
+"POT-Creation-Date: 2020-09-28 11:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,7 +23,7 @@ msgid "Tuner"
 msgstr ""
 
 #: data/com.github.louis77.tuner.desktop.in:5
-msgid "Internet Radio Station Receiver"
+msgid "Internet Radio Player"
 msgstr ""
 
 #: data/com.github.louis77.tuner.desktop.in:6
@@ -39,140 +39,174 @@ msgid "Radio;Audio;Listen;Stations;Receiver;"
 msgstr ""
 
 #: data/com.github.louis77.tuner.appdata.xml.in:9
+msgid "Louis Brauer"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:11
 msgid "Discover and listen to internet radio stations"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:12
+#: data/com.github.louis77.tuner.appdata.xml.in:14
 msgid "Make listening to internet radio stations fun again!"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:13
+#: data/com.github.louis77.tuner.appdata.xml.in:15
 msgid ""
 "Instead of providing you with all the stations you already know, Tuner "
 "presents you a new selection of stations from all over the world every time "
 "you hit the Shuffle button."
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:16
+#: data/com.github.louis77.tuner.appdata.xml.in:18
 msgid "Tuner uses the community-driven station catalog radio-browser.info."
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:18
+#: data/com.github.louis77.tuner.appdata.xml.in:20
 msgid "Discover new stations every day"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:19
-msgid "Star stations you like"
+#: data/com.github.louis77.tuner.appdata.xml.in:21
+msgid "Star stations you like and visit their website"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:20
+#: data/com.github.louis77.tuner.appdata.xml.in:22
 msgid "Control Tuner from your volume indicator"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:33
-msgid "Louis Brauer"
-msgstr ""
-
-#: data/com.github.louis77.tuner.appdata.xml.in:63
-#: data/com.github.louis77.tuner.appdata.xml.in:84
+#: data/com.github.louis77.tuner.appdata.xml.in:64
+#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:116
 msgid "New features:"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:65
+#: data/com.github.louis77.tuner.appdata.xml.in:66
+msgid "Show the current track playing if supported by station"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:67
+msgid "Show Top 100 stations of user country if detectable"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:68
+msgid "\"Visit Website\" link in station context menu"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:70
+#: data/com.github.louis77.tuner.appdata.xml.in:82
+#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:123
+msgid "Other improvements:"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:72
+msgid "Added Dutch translation"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:130
+msgid "Bugfixes:"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:76
+#: data/com.github.louis77.tuner.appdata.xml.in:89
+msgid "Fix missing icons for non elementary OS systems"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:84
+msgid "Add manual dark mode switch in settings"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:85
+msgid "Compact sidebar and content window"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:97
 msgid "Right-click a station to add or remove to favourites directly"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:66
+#: data/com.github.louis77.tuner.appdata.xml.in:98
 msgid ""
 "Add settings menu with \"Do-Not-Track\" option, disables sending station "
 "listening events to radio-browser.org"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:67
+#: data/com.github.louis77.tuner.appdata.xml.in:99
 msgid "Add About dialog"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:69
-#: data/com.github.louis77.tuner.appdata.xml.in:91
-msgid "Other improvements:"
-msgstr ""
-
-#: data/com.github.louis77.tuner.appdata.xml.in:71
+#: data/com.github.louis77.tuner.appdata.xml.in:103
 msgid ""
 "If a station is already in your favourites, you'll see a little star in the "
 "title"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:72
+#: data/com.github.louis77.tuner.appdata.xml.in:104
 msgid ""
 "Randomly selects one of the available radio-browser.org servers (was always "
 "de1 before)"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:73
+#: data/com.github.louis77.tuner.appdata.xml.in:105
 msgid ""
 "Favourites are now stored in a local favourites.json file to improve app "
 "startup time"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:106
 msgid "Added Italian translation"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:76
-#: data/com.github.louis77.tuner.appdata.xml.in:98
-msgid "Bugfixes:"
-msgstr ""
-
-#: data/com.github.louis77.tuner.appdata.xml.in:78
+#: data/com.github.louis77.tuner.appdata.xml.in:110
 msgid ""
 "Fix broken dark theme support (elementary and Adwaita dark look fine now)"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:86
+#: data/com.github.louis77.tuner.appdata.xml.in:118
 msgid "Search for radio stations"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:119
 msgid "New \"Genres\" section with select popular genres"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:88
+#: data/com.github.louis77.tuner.appdata.xml.in:120
 msgid "Added French translation"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:89
+#: data/com.github.louis77.tuner.appdata.xml.in:121
 msgid "Added German translation"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:93
+#: data/com.github.louis77.tuner.appdata.xml.in:125
 msgid "Each section now displays the most-voted-for 40 stations"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:94
+#: data/com.github.louis77.tuner.appdata.xml.in:126
 msgid "Station images are now being cached"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:127
 msgid "The app icon now appears more vertically centered"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:96
+#: data/com.github.louis77.tuner.appdata.xml.in:128
 msgid "Station images are now always the same size"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:100
+#: data/com.github.louis77.tuner.appdata.xml.in:132
 msgid "Fixed a bug where starred stations appeared as unstarred"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:133
 msgid "Display a nice API error screen"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:140
 msgid "New sidebar menu with different selections and your favourite stations."
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:113
+#: data/com.github.louis77.tuner.appdata.xml.in:145
 msgid "Initial release"
 msgstr ""

--- a/po/extra/fr.po
+++ b/po/extra/fr.po
@@ -1,13 +1,21 @@
+# French translations for extra package.
+# Copyright (C) 2020 THE extra'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the extra package.
+# Nathan Bonnemains (@NathanBnm), 2020.
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Tuner AppStream\n"
+"Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-10 19:42+0200\n"
+"POT-Creation-Date: 2020-09-28 11:55+0200\n"
+"PO-Revision-Date: 2020-09-28 11:53+0200\n"
+"Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
+"Language-Team: none\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: POEditor.com\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: data/com.github.louis77.tuner.desktop.in:4
 #: data/com.github.louis77.tuner.appdata.xml.in:8
@@ -15,7 +23,8 @@ msgid "Tuner"
 msgstr "Tuner"
 
 #: data/com.github.louis77.tuner.desktop.in:5
-msgid "Internet Radio Station Receiver"
+#, fuzzy
+msgid "Internet Radio Player"
 msgstr "Récepteur de stations de radio en ligne"
 
 #: data/com.github.louis77.tuner.desktop.in:6
@@ -31,14 +40,18 @@ msgid "Radio;Audio;Listen;Stations;Receiver;"
 msgstr "Radio;Audio;Listen;Stations;Receiver;"
 
 #: data/com.github.louis77.tuner.appdata.xml.in:9
+msgid "Louis Brauer"
+msgstr "Louis Brauer"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:11
 msgid "Discover and listen to internet radio stations"
 msgstr "Découvrez et écoutez des stations de radio en ligne"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:12
+#: data/com.github.louis77.tuner.appdata.xml.in:14
 msgid "Make listening to internet radio stations fun again!"
 msgstr "Rendons de nouveau fun l'écoute des stations de radio en ligne !"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:13
+#: data/com.github.louis77.tuner.appdata.xml.in:15
 msgid ""
 "Instead of providing you with all the stations you already know, Tuner "
 "presents you a new selection of stations from all over the world every time "
@@ -48,39 +61,81 @@ msgstr ""
 "Tuner vous présente une nouvelle sélection de stations du monde entier à "
 "chaque fois que vous appuyez sur le bouton « Aléatoire »."
 
-#: data/com.github.louis77.tuner.appdata.xml.in:16
+#: data/com.github.louis77.tuner.appdata.xml.in:18
 msgid "Tuner uses the community-driven station catalog radio-browser.info."
 msgstr ""
 "Tuner utilise le catalogue communautaire de stations radio-browser.info."
 
-#: data/com.github.louis77.tuner.appdata.xml.in:18
+#: data/com.github.louis77.tuner.appdata.xml.in:20
 msgid "Discover new stations every day"
 msgstr "Découvrez de nouvelles stations chaque jour"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:19
-msgid "Star stations you like"
+#: data/com.github.louis77.tuner.appdata.xml.in:21
+#, fuzzy
+msgid "Star stations you like and visit their website"
 msgstr "Marquez les stations que vous aimez comme favorites"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:20
+#: data/com.github.louis77.tuner.appdata.xml.in:22
 msgid "Control Tuner from your volume indicator"
 msgstr "Contrôlez la lecture de Tuner depuis votre indicateur de volume"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:33
-msgid "Louis Brauer"
-msgstr "Louis Brauer"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:63
-#: data/com.github.louis77.tuner.appdata.xml.in:84
+#: data/com.github.louis77.tuner.appdata.xml.in:64
+#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:116
 msgid "New features:"
 msgstr "Nouvelles fonctionnalités"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:65
+#: data/com.github.louis77.tuner.appdata.xml.in:66
+msgid "Show the current track playing if supported by station"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:67
+msgid "Show Top 100 stations of user country if detectable"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:68
+msgid "\"Visit Website\" link in station context menu"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:70
+#: data/com.github.louis77.tuner.appdata.xml.in:82
+#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:123
+msgid "Other improvements:"
+msgstr "Autres améliorations :"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:72
+#, fuzzy
+msgid "Added Dutch translation"
+msgstr "Traduction française ajoutée"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:130
+msgid "Bugfixes:"
+msgstr "Corrections de bug :"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:76
+#: data/com.github.louis77.tuner.appdata.xml.in:89
+msgid "Fix missing icons for non elementary OS systems"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:84
+msgid "Add manual dark mode switch in settings"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:85
+msgid "Compact sidebar and content window"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:97
 msgid "Right-click a station to add or remove to favourites directly"
 msgstr ""
 "Cliquez avec le bouton droit sur une station pour ajouter ou supprimer "
 "directement les favoris"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:66
+#: data/com.github.louis77.tuner.appdata.xml.in:98
 msgid ""
 "Add settings menu with \"Do-Not-Track\" option, disables sending station "
 "listening events to radio-browser.org"
@@ -88,16 +143,11 @@ msgstr ""
 "Ajouter le menu des paramètres avec l'option \"Ne pas suivre\", désactive "
 "l'envoi des événements d'écoute de la station à radio-browser.org"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:67
+#: data/com.github.louis77.tuner.appdata.xml.in:99
 msgid "Add About dialog"
 msgstr "Boîte de dialogue Ajouter à propos"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:69
-#: data/com.github.louis77.tuner.appdata.xml.in:91
-msgid "Other improvements:"
-msgstr "Autres améliorations :"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:71
+#: data/com.github.louis77.tuner.appdata.xml.in:103
 msgid ""
 "If a station is already in your favourites, you'll see a little star in the "
 "title"
@@ -105,7 +155,7 @@ msgstr ""
 "Si une station est déjà dans vos favoris, vous verrez une petite étoile dans "
 "le titre"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:72
+#: data/com.github.louis77.tuner.appdata.xml.in:104
 msgid ""
 "Randomly selects one of the available radio-browser.org servers (was always "
 "de1 before)"
@@ -113,7 +163,7 @@ msgstr ""
 "Sélectionne au hasard l'un des serveurs radio-browser.org disponibles (était "
 "toujours de1 avant)"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:73
+#: data/com.github.louis77.tuner.appdata.xml.in:105
 msgid ""
 "Favourites are now stored in a local favourites.json file to improve app "
 "startup time"
@@ -121,73 +171,68 @@ msgstr ""
 "Les favoris sont désormais stockés dans un fichier local favourites.json "
 "pour améliorer le temps de démarrage de l'application"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:106
 #, fuzzy
 msgid "Added Italian translation"
 msgstr "Traduction italienne ajoutée"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:76
-#: data/com.github.louis77.tuner.appdata.xml.in:98
-msgid "Bugfixes:"
-msgstr "Corrections de bug :"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:78
+#: data/com.github.louis77.tuner.appdata.xml.in:110
 msgid ""
 "Fix broken dark theme support (elementary and Adwaita dark look fine now)"
 msgstr ""
 "Correction de la prise en charge du thème sombre cassé (elementary et "
 "Adwaita theme semblent bien maintenant)"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:86
+#: data/com.github.louis77.tuner.appdata.xml.in:118
 msgid "Search for radio stations"
 msgstr "Recherchez des stations de radio"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:119
 msgid "New \"Genres\" section with select popular genres"
 msgstr "Nouvelle section « Genres » avec une sélection de genres populaires"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:88
+#: data/com.github.louis77.tuner.appdata.xml.in:120
 msgid "Added French translation"
 msgstr "Traduction française ajoutée"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:89
+#: data/com.github.louis77.tuner.appdata.xml.in:121
 msgid "Added German translation"
 msgstr "Traduction allemande ajoutée"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:93
+#: data/com.github.louis77.tuner.appdata.xml.in:125
 msgid "Each section now displays the most-voted-for 40 stations"
 msgstr "Chaque section affiche désormais les 40 stations les plus votées"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:94
+#: data/com.github.louis77.tuner.appdata.xml.in:126
 #, fuzzy
 msgid "Station images are now being cached"
 msgstr "Les images de station sont désormais mises en cache"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:127
 msgid "The app icon now appears more vertically centered"
 msgstr "L'icône de l'application est désormais mieux centrée verticalement"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:96
+#: data/com.github.louis77.tuner.appdata.xml.in:128
 #, fuzzy
 msgid "Station images are now always the same size"
 msgstr "Les images de station sont désormais mises en cache"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:100
+#: data/com.github.louis77.tuner.appdata.xml.in:132
 msgid "Fixed a bug where starred stations appeared as unstarred"
 msgstr ""
 "Correction d'un bug où les stations marquées comme favorites "
 "n'apparaissaient pas comme telles"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:133
 msgid "Display a nice API error screen"
 msgstr "Afficher un bel écran d'erreur API"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:140
 msgid "New sidebar menu with different selections and your favourite stations."
 msgstr ""
 "Nouveau menu dans la barre latérale avec différentes sélections et vos "
 "stations favorites."
 
-#: data/com.github.louis77.tuner.appdata.xml.in:113
+#: data/com.github.louis77.tuner.appdata.xml.in:145
 msgid "Initial release"
 msgstr "Version initiale"

--- a/po/extra/it.po
+++ b/po/extra/it.po
@@ -1,13 +1,21 @@
+# Italian translations for extra package.
+# Copyright (C) 2020 THE extra'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the extra package.
+# Automatically generated, 2020.
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Tuner AppStream\n"
+"Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-10 19:42+0200\n"
+"POT-Creation-Date: 2020-09-28 11:55+0200\n"
+"PO-Revision-Date: 2020-09-28 11:53+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: POEditor.com\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/com.github.louis77.tuner.desktop.in:4
 #: data/com.github.louis77.tuner.appdata.xml.in:8
@@ -15,7 +23,8 @@ msgid "Tuner"
 msgstr "Tuner"
 
 #: data/com.github.louis77.tuner.desktop.in:5
-msgid "Internet Radio Station Receiver"
+#, fuzzy
+msgid "Internet Radio Player"
 msgstr "Ricevitore della stazione radio Internet"
 
 #: data/com.github.louis77.tuner.desktop.in:6
@@ -31,14 +40,18 @@ msgid "Radio;Audio;Listen;Stations;Receiver;"
 msgstr "Radio;Audio;Listen;Stations;Receiver;"
 
 #: data/com.github.louis77.tuner.appdata.xml.in:9
+msgid "Louis Brauer"
+msgstr "Louis Brauer"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:11
 msgid "Discover and listen to internet radio stations"
 msgstr "Scopri e ascolta le stazioni radio Internet"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:12
+#: data/com.github.louis77.tuner.appdata.xml.in:14
 msgid "Make listening to internet radio stations fun again!"
 msgstr "Rendi di nuovo divertente l'ascolto delle stazioni radio Internet!"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:13
+#: data/com.github.louis77.tuner.appdata.xml.in:15
 msgid ""
 "Instead of providing you with all the stations you already know, Tuner "
 "presents you a new selection of stations from all over the world every time "
@@ -48,40 +61,82 @@ msgstr ""
 "nuova selezione di stazioni da tutto il mondo ogni volta che premi il "
 "pulsante Shuffle."
 
-#: data/com.github.louis77.tuner.appdata.xml.in:16
+#: data/com.github.louis77.tuner.appdata.xml.in:18
 msgid "Tuner uses the community-driven station catalog radio-browser.info."
 msgstr ""
 "Il sintonizzatore utilizza il catalogo delle stazioni gestito dalla comunità "
 "radio-browser.info."
 
-#: data/com.github.louis77.tuner.appdata.xml.in:18
+#: data/com.github.louis77.tuner.appdata.xml.in:20
 msgid "Discover new stations every day"
 msgstr "Scopri nuove stazioni ogni giorno"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:19
-msgid "Star stations you like"
+#: data/com.github.louis77.tuner.appdata.xml.in:21
+#, fuzzy
+msgid "Star stations you like and visit their website"
 msgstr "Aggiungi ai preferiti le stazioni che ti piacciono"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:20
+#: data/com.github.louis77.tuner.appdata.xml.in:22
 msgid "Control Tuner from your volume indicator"
 msgstr "Gestisci Tuner dall'indicatore del volume"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:33
-msgid "Louis Brauer"
-msgstr "Louis Brauer"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:63
-#: data/com.github.louis77.tuner.appdata.xml.in:84
+#: data/com.github.louis77.tuner.appdata.xml.in:64
+#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:116
 msgid "New features:"
 msgstr "Nuove caratteristiche:"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:65
+#: data/com.github.louis77.tuner.appdata.xml.in:66
+msgid "Show the current track playing if supported by station"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:67
+msgid "Show Top 100 stations of user country if detectable"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:68
+msgid "\"Visit Website\" link in station context menu"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:70
+#: data/com.github.louis77.tuner.appdata.xml.in:82
+#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:123
+msgid "Other improvements:"
+msgstr "Altri miglioramenti:"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:72
+#, fuzzy
+msgid "Added Dutch translation"
+msgstr "Aggiunta traduzione in francese"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:130
+msgid "Bugfixes:"
+msgstr "bugfix:"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:76
+#: data/com.github.louis77.tuner.appdata.xml.in:89
+msgid "Fix missing icons for non elementary OS systems"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:84
+msgid "Add manual dark mode switch in settings"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:85
+msgid "Compact sidebar and content window"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:97
 msgid "Right-click a station to add or remove to favourites directly"
 msgstr ""
 "Fare clic con il pulsante destro del mouse su una stazione per aggiungere o "
 "rimuovere direttamente dai preferiti"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:66
+#: data/com.github.louis77.tuner.appdata.xml.in:98
 msgid ""
 "Add settings menu with \"Do-Not-Track\" option, disables sending station "
 "listening events to radio-browser.org"
@@ -89,16 +144,11 @@ msgstr ""
 "Aggiunto il menu delle impostazioni con l'opzione \"Do-Not-Track\", "
 "disabilita l'invio di eventi di ascolto della stazione a radio-browser.org"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:67
+#: data/com.github.louis77.tuner.appdata.xml.in:99
 msgid "Add About dialog"
 msgstr "Aggiunta finestra di dialogo informazioni"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:69
-#: data/com.github.louis77.tuner.appdata.xml.in:91
-msgid "Other improvements:"
-msgstr "Altri miglioramenti:"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:71
+#: data/com.github.louis77.tuner.appdata.xml.in:103
 msgid ""
 "If a station is already in your favourites, you'll see a little star in the "
 "title"
@@ -106,7 +156,7 @@ msgstr ""
 "Se una stazione è già nei tuoi preferiti, vedrai una piccola stella nel "
 "titolo"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:72
+#: data/com.github.louis77.tuner.appdata.xml.in:104
 msgid ""
 "Randomly selects one of the available radio-browser.org servers (was always "
 "de1 before)"
@@ -114,7 +164,7 @@ msgstr ""
 "Seleziona casualmente uno dei server radio-browser.org disponibili (prima "
 "era sempre de1)"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:73
+#: data/com.github.louis77.tuner.appdata.xml.in:105
 msgid ""
 "Favourites are now stored in a local favourites.json file to improve app "
 "startup time"
@@ -122,71 +172,66 @@ msgstr ""
 "I preferiti sono ora archiviati in un file favourites.json locale per "
 "migliorare il tempo di avvio dell'app"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:106
 #, fuzzy
 msgid "Added Italian translation"
 msgstr "Aggiunta traduzione in italiano"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:76
-#: data/com.github.louis77.tuner.appdata.xml.in:98
-msgid "Bugfixes:"
-msgstr "bugfix:"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:78
+#: data/com.github.louis77.tuner.appdata.xml.in:110
 msgid ""
 "Fix broken dark theme support (elementary and Adwaita dark look fine now)"
 msgstr ""
 "Risolto il problema con il supporto del tema scuro rotto (elementary e "
 "Adwaita Dark sembrano a posto ora)"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:86
+#: data/com.github.louis77.tuner.appdata.xml.in:118
 msgid "Search for radio stations"
 msgstr "Cerca stazioni radio"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:119
 msgid "New \"Genres\" section with select popular genres"
 msgstr "Nuova sezione \"Generi\" con generi popolari selezionati"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:88
+#: data/com.github.louis77.tuner.appdata.xml.in:120
 msgid "Added French translation"
 msgstr "Aggiunta traduzione in francese"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:89
+#: data/com.github.louis77.tuner.appdata.xml.in:121
 msgid "Added German translation"
 msgstr "Aggiunta traduzione in tedesco"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:93
+#: data/com.github.louis77.tuner.appdata.xml.in:125
 msgid "Each section now displays the most-voted-for 40 stations"
 msgstr "Ogni sezione ora mostra le 40 stazioni più votate"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:94
+#: data/com.github.louis77.tuner.appdata.xml.in:126
 msgid "Station images are now being cached"
 msgstr "Le immagini delle stazioni radio ora vengono salvate nella cache"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:127
 msgid "The app icon now appears more vertically centered"
 msgstr "L'icona dell'app ora appare più centrata verticalmente"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:96
+#: data/com.github.louis77.tuner.appdata.xml.in:128
 msgid "Station images are now always the same size"
 msgstr "Le immagini delle stazioni radio ora hanno sempre le stesse dimensioni"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:100
+#: data/com.github.louis77.tuner.appdata.xml.in:132
 msgid "Fixed a bug where starred stations appeared as unstarred"
 msgstr ""
 "Risolto un bug in cui le stazioni contrassegnate apparivano come non "
 "contrassegnate"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:133
 msgid "Display a nice API error screen"
 msgstr "Mostra una bella schermata di errore API"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:140
 msgid "New sidebar menu with different selections and your favourite stations."
 msgstr ""
 "Nuovo menu della barra laterale con diverse selezioni e le tue stazioni "
 "preferite."
 
-#: data/com.github.louis77.tuner.appdata.xml.in:113
+#: data/com.github.louis77.tuner.appdata.xml.in:145
 msgid "Initial release"
 msgstr "Versione iniziale"

--- a/po/extra/nl.po
+++ b/po/extra/nl.po
@@ -1,22 +1,21 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Dutch translations for extra package.
+# Copyright (C) 2020 THE extra'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the extra package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Heimen Stoffels <vistausss@outlook.com>, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-10 19:42+0200\n"
-"PO-Revision-Date: 2020-09-01 13:57+0200\n"
-"Language-Team: \n"
+"POT-Creation-Date: 2020-09-28 11:55+0200\n"
+"PO-Revision-Date: 2020-09-28 11:53+0200\n"
+"Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
+"Language-Team: none\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.1\n"
-"Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: nl\n"
 
 #: data/com.github.louis77.tuner.desktop.in:4
 #: data/com.github.louis77.tuner.appdata.xml.in:8
@@ -24,7 +23,8 @@ msgid "Tuner"
 msgstr "Tuner"
 
 #: data/com.github.louis77.tuner.desktop.in:5
-msgid "Internet Radio Station Receiver"
+#, fuzzy
+msgid "Internet Radio Player"
 msgstr "Internetradio-ontvanger"
 
 #: data/com.github.louis77.tuner.desktop.in:6
@@ -40,14 +40,18 @@ msgid "Radio;Audio;Listen;Stations;Receiver;"
 msgstr "Radio;Audio;Luisteren;Stations;Ontvanger;"
 
 #: data/com.github.louis77.tuner.appdata.xml.in:9
+msgid "Louis Brauer"
+msgstr "Louis Brauer"
+
+#: data/com.github.louis77.tuner.appdata.xml.in:11
 msgid "Discover and listen to internet radio stations"
 msgstr "Ontdek en luister naar online-radiostations"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:12
+#: data/com.github.louis77.tuner.appdata.xml.in:14
 msgid "Make listening to internet radio stations fun again!"
 msgstr "Maak luisteren naar online-radiostreams weer leuk!"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:13
+#: data/com.github.louis77.tuner.appdata.xml.in:15
 msgid ""
 "Instead of providing you with all the stations you already know, Tuner "
 "presents you a new selection of stations from all over the world every time "
@@ -57,128 +61,159 @@ msgstr ""
 "selectie van radiostations van over heel de wereld, telkens als je op de "
 "knop 'Willekeurig' klikt."
 
-#: data/com.github.louis77.tuner.appdata.xml.in:16
+#: data/com.github.louis77.tuner.appdata.xml.in:18
 msgid "Tuner uses the community-driven station catalog radio-browser.info."
 msgstr ""
 "Tuner maakt gebruik van de door de gemeenschap bijgehouden catalogus op "
 "radio-browser.info"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:18
+#: data/com.github.louis77.tuner.appdata.xml.in:20
 msgid "Discover new stations every day"
 msgstr "Ontdek elke dag nieuwe radiostations"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:19
-msgid "Star stations you like"
+#: data/com.github.louis77.tuner.appdata.xml.in:21
+#, fuzzy
+msgid "Star stations you like and visit their website"
 msgstr "Voeg radiostations toe aan je favorieten"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:20
+#: data/com.github.louis77.tuner.appdata.xml.in:22
 msgid "Control Tuner from your volume indicator"
 msgstr "Bedien Tuner via de volume-indicator"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:33
-msgid "Louis Brauer"
-msgstr "Louis Brauer"
-
-#: data/com.github.louis77.tuner.appdata.xml.in:63
-#: data/com.github.louis77.tuner.appdata.xml.in:84
+#: data/com.github.louis77.tuner.appdata.xml.in:64
+#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:116
 msgid "New features:"
 msgstr "Nieuwe mogelijkheden:"
 
-#: data/com.github.louis77.tuner.appdata.xml.in:65
+#: data/com.github.louis77.tuner.appdata.xml.in:66
+msgid "Show the current track playing if supported by station"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:67
+msgid "Show Top 100 stations of user country if detectable"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:68
+msgid "\"Visit Website\" link in station context menu"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:70
+#: data/com.github.louis77.tuner.appdata.xml.in:82
+#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:123
+msgid "Other improvements:"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:72
+msgid "Added Dutch translation"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:130
+msgid "Bugfixes:"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:76
+#: data/com.github.louis77.tuner.appdata.xml.in:89
+msgid "Fix missing icons for non elementary OS systems"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:84
+msgid "Add manual dark mode switch in settings"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:85
+msgid "Compact sidebar and content window"
+msgstr ""
+
+#: data/com.github.louis77.tuner.appdata.xml.in:97
 msgid "Right-click a station to add or remove to favourites directly"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:66
+#: data/com.github.louis77.tuner.appdata.xml.in:98
 msgid ""
 "Add settings menu with \"Do-Not-Track\" option, disables sending station "
 "listening events to radio-browser.org"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:67
+#: data/com.github.louis77.tuner.appdata.xml.in:99
 msgid "Add About dialog"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:69
-#: data/com.github.louis77.tuner.appdata.xml.in:91
-msgid "Other improvements:"
-msgstr ""
-
-#: data/com.github.louis77.tuner.appdata.xml.in:71
+#: data/com.github.louis77.tuner.appdata.xml.in:103
 msgid ""
 "If a station is already in your favourites, you'll see a little star in the "
 "title"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:72
+#: data/com.github.louis77.tuner.appdata.xml.in:104
 msgid ""
 "Randomly selects one of the available radio-browser.org servers (was always "
 "de1 before)"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:73
+#: data/com.github.louis77.tuner.appdata.xml.in:105
 msgid ""
 "Favourites are now stored in a local favourites.json file to improve app "
 "startup time"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:74
+#: data/com.github.louis77.tuner.appdata.xml.in:106
 msgid "Added Italian translation"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:76
-#: data/com.github.louis77.tuner.appdata.xml.in:98
-msgid "Bugfixes:"
-msgstr ""
-
-#: data/com.github.louis77.tuner.appdata.xml.in:78
+#: data/com.github.louis77.tuner.appdata.xml.in:110
 msgid ""
 "Fix broken dark theme support (elementary and Adwaita dark look fine now)"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:86
+#: data/com.github.louis77.tuner.appdata.xml.in:118
 msgid "Search for radio stations"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:87
+#: data/com.github.louis77.tuner.appdata.xml.in:119
 msgid "New \"Genres\" section with select popular genres"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:88
+#: data/com.github.louis77.tuner.appdata.xml.in:120
 msgid "Added French translation"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:89
+#: data/com.github.louis77.tuner.appdata.xml.in:121
 msgid "Added German translation"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:93
+#: data/com.github.louis77.tuner.appdata.xml.in:125
 msgid "Each section now displays the most-voted-for 40 stations"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:94
+#: data/com.github.louis77.tuner.appdata.xml.in:126
 msgid "Station images are now being cached"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:95
+#: data/com.github.louis77.tuner.appdata.xml.in:127
 msgid "The app icon now appears more vertically centered"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:96
+#: data/com.github.louis77.tuner.appdata.xml.in:128
 msgid "Station images are now always the same size"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:100
+#: data/com.github.louis77.tuner.appdata.xml.in:132
 msgid "Fixed a bug where starred stations appeared as unstarred"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:101
+#: data/com.github.louis77.tuner.appdata.xml.in:133
 msgid "Display a nice API error screen"
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:108
+#: data/com.github.louis77.tuner.appdata.xml.in:140
 msgid "New sidebar menu with different selections and your favourite stations."
 msgstr ""
 
-#: data/com.github.louis77.tuner.appdata.xml.in:113
+#: data/com.github.louis77.tuner.appdata.xml.in:145
 msgid "Initial release"
 msgstr "Initiële uitgave"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,13 +1,21 @@
+# French translations for com.github.louis77.tuner package.
+# Copyright (C) 2020 THE com.github.louis77.tuner'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the com.github.louis77.tuner package.
+# Nathan Bonnemains (@NathanBnm), 2020.
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Tuner\n"
+"Project-Id-Version: com.github.louis77.tuner\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-06 01:26+0200\n"
+"POT-Creation-Date: 2020-09-28 11:51+0200\n"
+"PO-Revision-Date: 2020-09-28 11:48+0200\n"
+"Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
+"Language-Team: none\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: POEditor.com\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: src/Models/Genre.vala:35
 msgid "70s"
@@ -107,11 +115,11 @@ msgstr "Préférences"
 msgid "Station name"
 msgstr "Nom de la station"
 
-#: src/Widgets/HeaderBar.vala:134
+#: src/Widgets/HeaderBar.vala:130
 msgid "Star this station"
 msgstr "Marquer cette station comme favorite"
 
-#: src/Widgets/HeaderBar.vala:183
+#: src/Widgets/HeaderBar.vala:179
 msgid "Playing"
 msgstr "Lecture en cours"
 
@@ -127,7 +135,6 @@ msgstr ""
 msgid "Genres"
 msgstr "Genres"
 
-#. Discover Box
 #: src/Widgets/Window.vala:122
 msgid "Discover"
 msgstr "Découvrir"
@@ -140,7 +147,6 @@ msgstr "Découvrir des stations"
 msgid "Discover more stations"
 msgstr "Découvrir plus de stations"
 
-#. Trending Box
 #: src/Widgets/Window.vala:153
 msgid "Trending"
 msgstr "Tendances"
@@ -149,7 +155,6 @@ msgstr "Tendances"
 msgid "Trending in the last 24 hours"
 msgstr "Tendances des dernières 24 heures"
 
-#. Popular Box
 #: src/Widgets/Window.vala:174
 msgid "Popular"
 msgstr "Populaire"
@@ -158,7 +163,6 @@ msgstr "Populaire"
 msgid "Most-listened over 24 hours"
 msgstr "Les plus écoutées ces dernières 24 heures"
 
-#. Country-specific stations list
 #: src/Widgets/Window.vala:194
 #, fuzzy
 msgid "Your Country"
@@ -168,12 +172,10 @@ msgstr "Country"
 msgid "Top 100 in"
 msgstr ""
 
-#. Favourites Box
 #: src/Widgets/Window.vala:231 src/Widgets/Window.vala:235
 msgid "Starred by You"
 msgstr "Vos favoris"
 
-#. Search Results Box
 #: src/Widgets/Window.vala:244
 #, fuzzy
 msgid "Recent Search"
@@ -182,18 +184,3 @@ msgstr "Recherche"
 #: src/Widgets/Window.vala:248
 msgid "Search"
 msgstr "Recherche"
-
-#~ msgid "Paused"
-#~ msgstr "Mis en pause"
-
-#~ msgid "Connecting"
-#~ msgstr "Connexion"
-
-#~ msgid "Search Result"
-#~ msgstr "Résultats de recherche"
-
-#~ msgid "Buffering"
-#~ msgstr "Mise en mémoire tampon"
-
-#~ msgid "Stopped"
-#~ msgstr "Interrompu"

--- a/po/it.po
+++ b/po/it.po
@@ -1,13 +1,21 @@
+# Italian translations for com.github.louis77.tuner package.
+# Copyright (C) 2020 THE com.github.louis77.tuner'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the com.github.louis77.tuner package.
+# Automatically generated, 2020.
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Tuner\n"
+"Project-Id-Version: com.github.louis77.tuner\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-06 01:26+0200\n"
+"POT-Creation-Date: 2020-09-28 11:51+0200\n"
+"PO-Revision-Date: 2020-09-28 11:48+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: POEditor.com\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: src/Models/Genre.vala:35
 msgid "70s"
@@ -106,11 +114,11 @@ msgstr "Preferenze"
 msgid "Station name"
 msgstr "Nome stazione"
 
-#: src/Widgets/HeaderBar.vala:134
+#: src/Widgets/HeaderBar.vala:130
 msgid "Star this station"
 msgstr "Aggiungi ai preferiti"
 
-#: src/Widgets/HeaderBar.vala:183
+#: src/Widgets/HeaderBar.vala:179
 msgid "Playing"
 msgstr "Giocando"
 
@@ -126,7 +134,6 @@ msgstr ""
 msgid "Genres"
 msgstr "Generi"
 
-#. Discover Box
 #: src/Widgets/Window.vala:122
 msgid "Discover"
 msgstr "Scoprire"
@@ -139,7 +146,6 @@ msgstr "Scopri le stazioni"
 msgid "Discover more stations"
 msgstr "Scopri altre stazioni"
 
-#. Trending Box
 #: src/Widgets/Window.vala:153
 msgid "Trending"
 msgstr "Trending"
@@ -148,7 +154,6 @@ msgstr "Trending"
 msgid "Trending in the last 24 hours"
 msgstr "Di tendenza nelle ultime 24 ore"
 
-#. Popular Box
 #: src/Widgets/Window.vala:174
 msgid "Popular"
 msgstr "Popolare"
@@ -157,7 +162,6 @@ msgstr "Popolare"
 msgid "Most-listened over 24 hours"
 msgstr "I più ascoltati per 24 ore"
 
-#. Country-specific stations list
 #: src/Widgets/Window.vala:194
 #, fuzzy
 msgid "Your Country"
@@ -167,12 +171,10 @@ msgstr "Nazione"
 msgid "Top 100 in"
 msgstr ""
 
-#. Favourites Box
 #: src/Widgets/Window.vala:231 src/Widgets/Window.vala:235
 msgid "Starred by You"
 msgstr "I tuoi preferiti"
 
-#. Search Results Box
 #: src/Widgets/Window.vala:244
 #, fuzzy
 msgid "Recent Search"
@@ -181,18 +183,3 @@ msgstr "Ricerca"
 #: src/Widgets/Window.vala:248
 msgid "Search"
 msgstr "Ricerca"
-
-#~ msgid "Paused"
-#~ msgstr "In pausa"
-
-#~ msgid "Connecting"
-#~ msgstr "Collegamento"
-
-#~ msgid "Search Result"
-#~ msgstr "Risultato della ricerca"
-
-#~ msgid "Buffering"
-#~ msgstr "buffering"
-
-#~ msgid "Stopped"
-#~ msgstr "Fermato"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,21 +1,20 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Dutch translations for com.github.louis77.tuner package.
+# Copyright (C) 2020 THE com.github.louis77.tuner'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the com.github.louis77.tuner package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Automatically generated, 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: com.github.louis77.tuner\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-06 01:26+0200\n"
-"PO-Revision-Date: 2020-09-01 13:53+0200\n"
-"Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
-"Language-Team: \n"
+"POT-Creation-Date: 2020-09-28 11:51+0200\n"
+"PO-Revision-Date: 2020-09-28 11:48+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: src/Models/Genre.vala:35
@@ -114,11 +113,11 @@ msgstr "Voorkeuren"
 msgid "Station name"
 msgstr "Naam van radiostation"
 
-#: src/Widgets/HeaderBar.vala:134
+#: src/Widgets/HeaderBar.vala:130
 msgid "Star this station"
 msgstr "Toevoegen aan fovorieten"
 
-#: src/Widgets/HeaderBar.vala:183
+#: src/Widgets/HeaderBar.vala:179
 msgid "Playing"
 msgstr "Je luistert naar"
 
@@ -134,7 +133,6 @@ msgstr ""
 msgid "Genres"
 msgstr "Genres"
 
-#. Discover Box
 #: src/Widgets/Window.vala:122
 msgid "Discover"
 msgstr "Bladeren"
@@ -147,7 +145,6 @@ msgstr "Ontdek radiostations"
 msgid "Discover more stations"
 msgstr "Meer radiostations tonen"
 
-#. Trending Box
 #: src/Widgets/Window.vala:153
 msgid "Trending"
 msgstr "Trending"
@@ -156,7 +153,6 @@ msgstr "Trending"
 msgid "Trending in the last 24 hours"
 msgstr "Populair in de afgelopen 24 uur"
 
-#. Popular Box
 #: src/Widgets/Window.vala:174
 msgid "Popular"
 msgstr "Populair"
@@ -165,7 +161,6 @@ msgstr "Populair"
 msgid "Most-listened over 24 hours"
 msgstr "Meest beluisterd in de afgelopen 24 uur"
 
-#. Country-specific stations list
 #: src/Widgets/Window.vala:194
 #, fuzzy
 msgid "Your Country"
@@ -175,12 +170,10 @@ msgstr "Country"
 msgid "Top 100 in"
 msgstr ""
 
-#. Favourites Box
 #: src/Widgets/Window.vala:231 src/Widgets/Window.vala:235
 msgid "Starred by You"
 msgstr "Favorieten"
 
-#. Search Results Box
 #: src/Widgets/Window.vala:244
 #, fuzzy
 msgid "Recent Search"
@@ -189,18 +182,3 @@ msgstr "Zoeken"
 #: src/Widgets/Window.vala:248
 msgid "Search"
 msgstr "Zoeken"
-
-#~ msgid "Paused"
-#~ msgstr "Onderbroken"
-
-#~ msgid "Connecting"
-#~ msgstr "Bezig met verbinden"
-
-#~ msgid "Search Result"
-#~ msgstr "Zoekresultaat"
-
-#~ msgid "Buffering"
-#~ msgstr "Bezig met bufferen"
-
-#~ msgid "Stopped"
-#~ msgstr "Gestopt"


### PR DESCRIPTION
Translation file headers where not properly formatted so here is a fix.