### PR TITLE
Added Flatpak manifest for Elementary 6

### DIFF
--- a/com.github.louis77.tuner.yml
+++ b/com.github.louis77.tuner.yml
@@ -49,5 +49,5 @@ modules:
   post-install:
   - install -Dm644 /app/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.svg  -t /app/share/icons/hicolor/128x128/apps/
   sources:
-  - type: git
-    url: https://github.com/louis77/tuner.git
+  - type: dir
+    path: .

--- a/com.github.louis77.tuner.yml
+++ b/com.github.louis77.tuner.yml
@@ -1,0 +1,53 @@
+---
+app-id: com.github.louis77.tuner
+runtime: io.elementary.Platform
+runtime-version: '6'
+sdk: io.elementary.Sdk
+command: com.github.louis77.tuner
+finish-args:
+- "--share=ipc"
+- "--socket=fallback-x11"
+- "--socket=wayland"
+- "--talk-name=org.gtk.vfs"
+- "--talk-name=org.gtk.vfs.*"
+- "--share=network"
+- "--metadata=X-DConf=migrate-path=/com/github/louis77/tuner/"
+- "--socket=pulseaudio"
+- "--talk-name=org.freedesktop.Notifications"
+- "--talk-name=org.gnome.SettingsDaemon.MediaKeys"
+- "--own-name=org.mpris.MediaPlayer2.Tuner"
+cleanup:
+- "/include"
+- "/lib/pkgconfig"
+- "/share/pkgconfig"
+- "/share/aclocal"
+- "/man"
+- "/share/man"
+- "/share/gtk-doc"
+- "/share/vala"
+- "*.la"
+- "*.a"
+modules:
+- name: taglib
+  buildsystem: cmake-ninja
+  config-opts:
+  - "-DBUILD_SHARED_LIBS=ON"
+  - "-DCMAKE_BUILD_TYPE=Release"
+  sources:
+  - type: archive
+    url: https://github.com/taglib/taglib/archive/v1.11.1.tar.gz
+    sha256: b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b
+- name: libgeocode-glib0
+  buildsystem: meson
+  sources:
+  - type: git
+    url: https://gitlab.gnome.org/GNOME/geocode-glib.git
+- name: tuner
+  buildsystem: meson
+  config-opts:
+  - "--buildtype=release"
+  post-install:
+  - install -Dm644 /app/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.svg  -t /app/share/icons/hicolor/128x128/apps/
+  sources:
+  - type: git
+    url: https://github.com/louis77/tuner.git


### PR DESCRIPTION
This takes the existing manifest from Flathub and makes it compatible with Elementary OS 6.0 so that it can work in the AppCenter.