### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,15 @@ add_project_arguments (
     language: 'c'
 )
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 # Compiling resources
 asresources = gnome.compile_resources (
     'as-resources',
@@ -50,6 +59,7 @@ subdir ('src')
 executable (
     meson.project_name (),
     asresources,
+    config_file,
     sources,
     dependencies: dependencies,
     install: true

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -40,6 +40,11 @@ public class Tuner.Application : Gtk.Application {
     }
 
     construct {
+        GLib.Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        GLib.Intl.textdomain (GETTEXT_PACKAGE);
+
         settings = new GLib.Settings (this.application_id);
         player = new PlayerController ();
 

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;


### PR DESCRIPTION
Fixes #56

To prevent the flatpaked version of the app always being shown in English

Borrowed [the code written by tintou](https://github.com/elementary/camera/commit/33c7e17003d1ead422345624633a4cf0726a6c93)
