### PR TITLE
Add adjustable search delay for debouncing

### DIFF
--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -28,6 +28,22 @@ public class Tuner.HeaderBar : Gtk.HeaderBar {
     public signal void star_clicked (bool starred);
     public signal void searched_for (string text);
     public signal void search_focused ();
+    
+    private int search_delay = 250; // search delay in milliseconds (ms)
+    private uint delayed_changed_id;
+    private string searchentry_text = "";
+    private void reset_timeout(){
+        if(delayed_changed_id > 0)
+            Source.remove(delayed_changed_id);
+        delayed_changed_id = Timeout.add(search_delay, timeout);
+    }
+    
+    private bool timeout(){
+        // perform search
+        searched_for (searchentry_text);
+        delayed_changed_id = 0;
+        return false;
+    }
 
     construct {
         show_close_button = true;
@@ -64,7 +80,8 @@ public class Tuner.HeaderBar : Gtk.HeaderBar {
         searchentry.valign = Gtk.Align.CENTER;
         searchentry.placeholder_text = _("Station name");
         searchentry.search_changed.connect (() => {
-            searched_for (searchentry.text);
+            searchentry_text = searchentry.text;
+            reset_timeout();
         });
         searchentry.focus_in_event.connect ((e) => {
             search_focused ();


### PR DESCRIPTION
Addresses #82 

Currently Gtk.SearchEntry() has a default debouncing timeout of 150ms which is not adjustable. This PR adds an adjustable debouncing timeout to prevent the app from freezing the moment the user types in the search bar.

Reference
https://stackoverflow.com/questions/41553160/vala-how-to-asynchronously-wait-for-x-seconds-and-execute-something-then