### PR TITLE
Fixed tint2 not finding icon, because tint2 gets icon from window not desktop file

### DIFF
--- a/src/Widgets/Window.vala
+++ b/src/Widgets/Window.vala
@@ -57,6 +57,8 @@ public class Tuner.Window : Gtk.ApplicationWindow {
     }
 
     construct {
+        this.set_icon_name("com.github.louis77.tuner");
+
         headerbar = new HeaderBar ();
         set_titlebar (headerbar);
         set_title (WindowName);


### PR DESCRIPTION
When using tint2 the icon doesn't appear for the application as tint2 gets in the window hints, not the desktop file. Setting the window icon fixes the issue.