### PR TITLE
data/meson.build: fix install schemas

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -75,7 +75,12 @@ settings_schemas = [ meson.project_name() + '.gschema.xml' ]
 
 install_data(settings_schemas, install_dir: schemas_dir)
 
-meson.add_install_script('glib-compile-schemas', schemas_dir, install_tag: 'schemas')
+meson.add_install_script(
+    'glib-compile-schemas',
+    '--targetdir=' + meson.project_build_root(),
+    schemas_dir,
+    install_tag: 'schemas'
+)
 
 
 message('Installed schema\n')


### PR DESCRIPTION
Add the --targetdir= to specify where to store the gschemas.compiled file

Fix the following:
```
Running custom install script '/usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas'
Failed to create file “/usr/share/glib-2.0/schemas/gschemas.compiled.H6JUZ2”: Permission denied
FAILED: install script '/usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas' failed with exit code 1.
```

Fixes https://github.com/louis77/tuner/issues/215