### PR TITLE
Do not install intermediate translation files

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -49,8 +49,7 @@ foreach lang : run_command('cat', 'LINGUAS', check: true).stdout().strip().split
                 '-o', '@OUTPUT@'
             ],
             build_by_default: true,
-            install: true,
-            install_dir: join_paths(get_option('localedir'), lang, 'LC_MESSAGES')
+            install: false,
         )
     endif
 endforeach


### PR DESCRIPTION
Intermediate files get installed as:
```
Installing po/de.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/de/LC_MESSAGES
Installing po/fr.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/fr/LC_MESSAGES
Installing po/it.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/it/LC_MESSAGES
Installing po/nl.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/nl/LC_MESSAGES
Installing po/pt_BR.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/pt_BR/LC_MESSAGES
Installing po/tr.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/tr/LC_MESSAGES
Installing po/nb_NO.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/nb_NO/LC_MESSAGES
Installing po/ru.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/ru/LC_MESSAGES
Installing po/es.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/es/LC_MESSAGES
Installing po/ja.mo to /builddir/build/BUILD/tuner-2.0.0-build/BUILDROOT/usr/share/locale/ja/LC_MESSAGES
```

They have incorrect names.