### PR TITLE
RevealLabel: replace cross-thread mutex usage with state flag

### DIFF
--- a/src/Widgets/base/RevealLabel.vala
+++ b/src/Widgets/base/RevealLabel.vala
@@ -22,7 +22,7 @@
  */
 public class Tuner.Widgets.Base.RevealLabel : Gtk.Revealer 
 {
-    private Mutex _set_text_lock = Mutex();   // Lock out concurrent updates
+    private bool _set_text_busy = false;    // Lock out concurrent updates
     private string _next_text;
 
     /**
@@ -81,7 +81,10 @@ public class Tuner.Widgets.Base.RevealLabel : Gtk.Revealer
         // Prevent transition if same title is submitted multiple times
         if ( label_child.label == text) return true;      
         
-        if ( _set_text_lock.trylock() == false ) return false;
+        if (_set_text_busy)
+        return false;
+
+        _set_text_busy = true;
 
         reveal_child = false;
         _next_text = text;
@@ -91,7 +94,7 @@ public class Tuner.Widgets.Base.RevealLabel : Gtk.Revealer
         {
             label_child.label = _next_text;
             reveal_child = true;
-            _set_text_lock.unlock ();
+              _set_text_busy = false;
             return true;
         }
 
@@ -107,7 +110,7 @@ public class Tuner.Widgets.Base.RevealLabel : Gtk.Revealer
         {
             label_child.label = _next_text;
             reveal_child = true;
-            _set_text_lock.unlock ();
+              _set_text_busy = false;
             return Source.REMOVE;
         }, Priority.DEFAULT_IDLE);    
         


### PR DESCRIPTION
After porting Tuner to OpenBSD, the application would intermittently
abort in g_mutex_unlock().

GDB showed that RevealLabel.set_text() could acquire
_set_text_lock from a worker thread, while the corresponding unlock
occurred later from a GLib timeout callback running on the GTK main
thread.

Unlocking a mutex from a thread other than the owner is undefined
behaviour and triggers SIGABRT on OpenBSD.

The mutex was being used as a state flag to prevent overlapping text
animations rather than to protect shared data, so this patch replaces
it with a simple boolean flag.

I have also built the patched version (git main branch) on Arch Linux and it runs without problems.